### PR TITLE
Precompute H-rep to speedup is_intersection_empty

### DIFF
--- a/src/PartitionBasedAbstraction/controller.jl
+++ b/src/PartitionBasedAbstraction/controller.jl
@@ -12,7 +12,10 @@ function localise(partition::Partition,Q::AbstractPolytope)
     @warn("Out of domain")
 end
 
-function control(X0::AbstractPolytope,Xf::AbstractPolytope,partition::Partition,topological_graph::LightTopologicalGraph,contsys::ControlSystem{N,T},obstacles,_U_,hu,hx_l) where{N,T}
+function control(X0::AbstractPolytope,Xf::AbstractPolytope,partition::Partition,topological_graph::LightTopologicalGraph,contsys::ControlSystem{N},obstacles,_U_,hu,hx_l) where N
+    # We need the H-representation for `is_intersection_empty` so we compute it here
+    # to avoid having to compute it many times
+    h_obstacles = LazySets.tohrep.(obstacles)
     p0 = localise(partition,X0)
     pf = localise(partition,Xf)
     path = get_path(topological_graph,p0,pf)
@@ -24,7 +27,7 @@ function control(X0::AbstractPolytope,Xf::AbstractPolytope,partition::Partition,
         #temporary
         #parameters of the abstraction, could decide here a different state-input space discretization
         hx = SVector{N}(hx_l[i])
-        push!(time_abstraction,@elapsed symmodel = build_abstraction(partition.L[path[i]],hx,_U_,hu,contsys,obstacles))
+        push!(time_abstraction,@elapsed symmodel = build_abstraction(partition.L[path[i]],hx,_U_,hu,contsys,h_obstacles))
         #local inputs
         initlist = get_symbols(_I_,symmodel,AB.OUTER)
         #local targets

--- a/src/PartitionBasedAbstraction/partition.jl
+++ b/src/PartitionBasedAbstraction/partition.jl
@@ -2,14 +2,14 @@ module PartitionAbstraction
 using LinearAlgebra,StaticArrays,Plots,Polyhedra,LazySets
 import LazySets.AbstractPolytope
 
-include("..//Abstraction//abstraction.jl")
+include(joinpath("..", "Abstraction", "abstraction.jl"))
 using .Abstraction
 AB = Abstraction
 include("constrainedZonotope.jl")
 
 mutable struct Partition{T}
     X::T
-    L::Vector{<:T}
+    L::Vector{T}
 end
 
 function get_vertices(X::T,L::Vector{<:T}) where T

--- a/src/PartitionBasedAbstraction/symbolicmodel.jl
+++ b/src/PartitionBasedAbstraction/symbolicmodel.jl
@@ -3,12 +3,9 @@ import .Abstraction.compute_symmodel_from_controlsystem!
 
 #true si P intersect un des sets de L
 function intersect_union(P,L)
-    for l in L
-        if !is_intersection_empty(P,l)
-            return true
-        end
+    return any(L) do l
+        !is_intersection_empty(P,l)
     end
-    return false
 end
 
 # return symbols of cells of the abstraction fully contained in P or intersecting P
@@ -51,7 +48,7 @@ function mesh(P::AbstractPolytope{T}, Δ::SVector{N,T},obstacles::Vector) where 
     for pos in Iterators.product(AB._ranges(rectI)...)
         center = Array(AB.get_coord_by_pos(grid, pos))
         cell = Hyperrectangle(center,grid.h./2)
-        if center ∈ P && !intersect_union(cell,obstacles)
+        if center ∈ P && !intersect_union(cell, obstacles)
             AB.add_pos!(domain, pos)
         end
     end


### PR DESCRIPTION
A large part of the computation time was spent computing the H-rep of the obstacles at every call of `is_intersection_empty` which can be seen thanks to [ProfileView](https://github.com/timholy/ProfileView.jl).
Before:
```
Elapsed time
Abstractions : Any[0.385914439, 0.430972114, 0.801604122, 0.184807019]
Controllers  : Any[0.007796395, 0.008066114, 0.029999836, 0.003614486]
Total Abstractions : 1.8032976939999998
Total Controllers  : 0.049476831
```
After:
```
Elapsed time
Abstractions : Any[0.141498168, 0.166098547, 0.414786503, 0.136524917]
Controllers  : Any[0.008132006, 0.006809145, 0.028751302, 0.004085724]
Total Abstractions : 0.8589081350000001
Total Controllers  : 0.047778177
```