### PR TITLE
Remove union for sorted vector set

### DIFF
--- a/src/utils/data_structures/sorted_vector_set.jl
+++ b/src/utils/data_structures/sorted_vector_set.jl
@@ -19,16 +19,16 @@ function append_new!(set::SortedTupleSet, xs)
     return set
 end
 
-function append_new!(set, xs::Vector)
-    union!(set, xs)
-    return set
-end
-
-function append_new!(set::SortedTupleSet, xs::Vector)
-    union!(set.data, xs)
-    set.is_sorted = false
-    return set
-end
+#function append_new!(set, xs::Vector)
+#    union!(set, xs)
+#    return set
+#end
+#
+#function append_new!(set::SortedTupleSet, xs::Vector)
+#    union!(set.data, xs)
+#    set.is_sorted = false
+#    return set
+#end
 
 function delete!(set::SortedTupleSet, x, comparison)
     filter!(e->!comparison(e,x), set.data)

--- a/src/utils/data_structures/sorted_vector_set.jl
+++ b/src/utils/data_structures/sorted_vector_set.jl
@@ -19,11 +19,11 @@ function append_new!(set::SortedTupleSet, xs)
     return set
 end
 
-#function append_new!(set, xs::Vector)
-#    union!(set, xs)
-#    return set
-#end
-#
+function append_new!(set::Set, xs::Vector)
+    union!(set, xs)
+    return set
+end
+
 #function append_new!(set::SortedTupleSet, xs::Vector)
 #    union!(set.data, xs)
 #    set.is_sorted = false

--- a/test/control/test_controllerreach.jl
+++ b/test/control/test_controllerreach.jl
@@ -75,7 +75,7 @@ if VERSION >= v"1.5"
         @allocated CO._compute_controller_reach!(contr, autom, initset, targetset, num_targets_unreachable, current_targets, next_targets)
     end
     f(symmodel.autom, initlist, targetlist)
-    @test f(symmodel.autom, initlist, targetlist) == 1635072 # check this
+    @test f(symmodel.autom, initlist, targetlist) == 3224896 # check this
 end
 
 xpos = DO.get_somepos(Xinit)


### PR DESCRIPTION
@JulienCalbert This is making the docs build never finish because `union!` is way slower than `append!` which is done by the method above than is never called because of the new methods. Why are these methods needed ?