### PR TITLE
fixed _get_min_bounding_box and added more tests

### DIFF
--- a/src/symbolic/ellipsoidal_transitions.jl
+++ b/src/symbolic/ellipsoidal_transitions.jl
@@ -278,7 +278,7 @@ function _get_min_bounding_box(P, optimizer)
     for i in 1:n
         new_model, reference_map = copy_model(model)
         set_optimizer(new_model,optimizer)
-        @objective(new_model, Max, reference_map[x[i]]*reference_map[x[i]])
+        @objective(new_model, Max, reference_map[x[i]])
         optimize!(new_model)
         R[i] = abs(value(reference_map[x[i]]))
     end

--- a/src/symbolic/ellipsoidal_transitions.jl
+++ b/src/symbolic/ellipsoidal_transitions.jl
@@ -225,7 +225,7 @@ function _provide_P(subsys::HybridSystems.ConstrainedAffineControlDiscreteSystem
     model = Model(optimizer)
     @variable(model, L[i=1:m,j=1:n]) 
     @variable(model, S[i=1:n,j=1:n], PSD) 
-    @variable(model, gamma >= 0)
+    @variable(model, gamma)
 
 
 
@@ -233,12 +233,12 @@ function _provide_P(subsys::HybridSystems.ConstrainedAffineControlDiscreteSystem
 
     
     @constraint(model, [S      t(A*S+B*L);
-                        A*S+B*L    S]        >= 0, PSDCone())
+                        A*S+B*L    S]        >= 1e-4*eye(2n), PSDCone())
     @constraint(model, eye(n) >= S, PSDCone())
-    @constraint(model, S >= -gamma*eye(n), PSDCone())
+    @constraint(model, S >= gamma*eye(n), PSDCone())
 
     
-    @objective(model, Min, gamma)
+    @objective(model, Max, gamma)
 
     #print(model)
     optimize!(model)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,8 @@ include("./domain/test_general_domain.jl")
 include("./symbolic/test_automaton.jl")
 include("./symbolic/test_symbolicmodel.jl")
 include("./symbolic/test_lazy_symbolic.jl")
+include("./symbolic/test_ellipsoidal_transitions.jl")
+
 
 include("./control/test_fromcontrolsystemgrowth.jl")
 include("./control/test_fromcontrolsystemlinearized.jl")

--- a/test/symbolic/test_ellipsoidal_transitions.jl
+++ b/test/symbolic/test_ellipsoidal_transitions.jl
@@ -1,0 +1,41 @@
+module TestMain
+
+using Test
+using Dionysos
+using SDPA, Ipopt, JuMP
+using HybridSystems
+
+const DI = Dionysos
+const SY = DI.Symbolic
+
+sleep(0.1) # used for good printing
+println("Started test")
+
+@testset "Get min bounding box" begin
+    opt_qp = optimizer_with_attributes(Ipopt.Optimizer, MOI.Silent() => true)
+    P = [1.0 0.0;
+         0.0 0.25]
+    x = SY._get_min_bounding_box(P, opt_qp)
+    @test x ≈ [1.0, 2.0] atol=1e-2
+    P = [1.5 -0.5; -0.5 2.5]
+    x = SY._get_min_bounding_box(P, opt_qp)
+    @test x ≈ [0.84515, 0.65465] atol=1e-2
+end
+
+@testset "Provide P" begin
+    opt_sdp = optimizer_with_attributes(SDPA.Optimizer, MOI.Silent() => true)
+    A = [0.0 1.0 0.0; 
+         0.0 0.0 1.0; 
+         2.0 1.0 5.0]
+    B = [0.0; 0.0; 1.0][:,:]
+    c = zeros(3)
+
+    sys = HybridSystems.ConstrainedAffineControlDiscreteSystem(A,B,c,Nothing, Nothing)
+    ans, K, P, gamma = SY._provide_P(sys, opt_sdp)
+    @test K ≈ [-1.97742  -1.0  -5.0] atol=1e-2
+end
+
+sleep(0.1) # used for good printing
+println("End test")
+
+end  # module TestMain

--- a/test/symbolic/test_ellipsoidal_transitions.jl
+++ b/test/symbolic/test_ellipsoidal_transitions.jl
@@ -8,7 +8,6 @@ using HybridSystems
 const DI = Dionysos
 const SY = DI.Symbolic
 
-sleep(0.1) # used for good printing
 println("Started test")
 
 @testset "Get min bounding box" begin
@@ -35,7 +34,6 @@ end
     @test K ≈ [-1.97742  -1.0  -5.0] atol=1e-2
 end
 
-sleep(0.1) # used for good printing
 println("End test")
 
 end  # module TestMain


### PR DESCRIPTION
Change the objective function of this `_get_min_bounding_box` by an equivalent (and linear) one. Before the quadratic objective function was working but now it is not (maybe a bug on JuMP/Ipopt?). The test didn't catch this so I am writing better tests. I am also making `_provide_P` more robust and added a test for it