### PR TITLE
Fix identation documentation.yml

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,29 +9,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      
-      - name: Install LaTeX
-        run:  sudo apt-get update && sudo apt-get -y install ghostscript texlive texlive-latex-extra texlive-fonts-recommended cm-super dvipng
-
-      
-      
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.9
-          cache: 'pip'
-      - run: python -m pip install -r requirements.txt
-      - uses: julia-actions/setup-julia@latest
-        with:
-          # Build documentation on the latest Julia 1.x
-          version: '1'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.instantiate();
-                                       Pkg.develop(PackageSpec(path=pwd()))'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-	  GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988
-        run: julia --project=docs/ docs/make.jl
+    - uses: actions/checkout@v2
+    - name: Install LaTeX
+      run:  sudo apt-get update && sudo apt-get -y install ghostscript texlive texlive-latex-extra texlive-fonts-recommended cm-super dvipng     
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+        cache: 'pip'
+    - run: python -m pip install -r requirements.txt
+    - uses: julia-actions/setup-julia@latest
+      with:
+        # Build documentation on the latest Julia 1.x
+        version: '1'
+    - name: Install dependencies
+      run: julia --project=docs/ -e 'using Pkg; Pkg.instantiate();
+                                     Pkg.develop(PackageSpec(path=pwd()))'
+    - name: Build and deploy
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
+        DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
+        GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988
+      run: julia --project=docs/ docs/make.jl


### PR DESCRIPTION
@JulienCalbert

After `steps` one shouldn't indent, says https://github.com/actions/starter-workflows/issues/508 