### PR TITLE
Use underscore package

### DIFF
--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -3,6 +3,7 @@
 \setcounter{page}{1}
 
 % added
+\usepackage{underscore}
 \usepackage{amsmath}
 
 \begin{document}

--- a/paper/ref.bib
+++ b/paper/ref.bib
@@ -147,7 +147,7 @@
   pages={351--365},
   year={2009},
   organization={Springer},
-  doi={10.1007/978-3-642-00602-9\textunderscore25}
+  doi={10.1007/978-3-642-00602-9_25}
 }
 
 %%%%%%%%%%%%%%%%%% Toolboxes
@@ -158,7 +158,7 @@
   pages={566--569},
   year={2010},
   organization={Springer},
-  doi={10.1007/978-3-642-14295-6\textunderscore49}
+  doi={10.1007/978-3-642-14295-6_49}
 }
 
 @inproceedings{rungger2016scots,
@@ -238,7 +238,7 @@
   pages={477--492},
   year={2004},
   organization={Springer}, 
-  doi={10.1007/978-3-540-24743-2\textunderscore32}
+  doi={10.1007/978-3-540-24743-2_32}
 }
 
 %%%%%%%%%%%%%%%%%% L2C


### PR DESCRIPTION
@adrienbanse it doesn't seem to break the equations for me.
They write in here: https://ctan.org/pkg/underscore?lang=en

> the behaviour of `_` in maths mode is not affected" so I thought it would work