### PR TITLE
Rename discretization functions

### DIFF
--- a/docs/src/examples/Getting Started.jl
+++ b/docs/src/examples/Getting Started.jl
@@ -80,7 +80,7 @@ measnoise = SVector(0.0, 0.0);
 sysnoise = SVector(0.0, 0.0);
 
 # And now the instantiation of the ControlSystem
-contsys = ST.NewControlSystemGrowthRK4(
+contsys = ST.discretize_system_with_growth_bound(
     tstep,
     F_sys,
     L_growthbound,

--- a/src/optim/abstraction/uniform_grid_abstraction.jl
+++ b/src/optim/abstraction/uniform_grid_abstraction.jl
@@ -115,7 +115,7 @@ function discretized_system(
         if isnothing(model.jacobian_bound)
             error("Please set the `jacobian_bound`.")
         end
-        return Dionysos.System.NewControlSystemGrowthRK4(
+        return Dionysos.System.discretize_system_with_growth_bound(
             model.time_step,
             concrete_system.f,
             model.jacobian_bound,
@@ -125,7 +125,7 @@ function discretized_system(
             model.num_sub_steps_growth_bound,
         )
     elseif model.approx_mode == LINEARIZED
-        return Dionysos.System.NewControlSystemLinearizedRK4(
+        return Dionysos.System.discretize_system_with_linearization(
             model.time_step,
             concrete_system.f,
             model.jacobian,

--- a/src/system/controlsystem.jl
+++ b/src/system/controlsystem.jl
@@ -41,7 +41,7 @@ struct ControlSystemGrowth{N, T, F1 <: Function, F2 <: Function, F3 <: Function}
     sys_inv_map::F3
 end
 
-function NewControlSystemGrowthRK4(
+function discretize_system_with_growth_bound(
     tstep,
     F_sys,
     L_growthbound,
@@ -128,7 +128,7 @@ function BoundSecondOrder(a, b, tstep)
     end
 end
 
-function NewControlSystemLinearizedRK4(
+function discretize_system_with_linearization(
     tstep,
     F_sys,
     DF_sys,

--- a/test/optim/unit_tests_UniformGridAbstraction/test_controllerreach.jl
+++ b/test/optim/unit_tests_UniformGridAbstraction/test_controllerreach.jl
@@ -45,7 +45,7 @@ println("Started test")
     measnoise = SVector(1.0, 1.0) * 0.001
     L_growthbound(u) = SMatrix{2, 2}(0.0, 0.0, 0.0, 0.0)
 
-    contsys = ST.NewControlSystemGrowthRK4(
+    contsys = ST.discretize_system_with_growth_bound(
         tstep,
         F_sys,
         L_growthbound,

--- a/test/optim/unit_tests_UniformGridAbstraction/test_controllersafe.jl
+++ b/test/optim/unit_tests_UniformGridAbstraction/test_controllersafe.jl
@@ -39,7 +39,7 @@ println("Started test")
     measnoise = SVector(1.0, 1.0) * 0.001
     L_growthbound(u) = SMatrix{2, 2}(0.0, 0.0, 0.0, -1.0)
 
-    contsys = ST.NewControlSystemGrowthRK4(
+    contsys = ST.discretize_system_with_growth_bound(
         tstep,
         F_sys,
         L_growthbound,

--- a/test/optim/unit_tests_UniformGridAbstraction/test_fromcontrolsystemgrowth.jl
+++ b/test/optim/unit_tests_UniformGridAbstraction/test_fromcontrolsystemgrowth.jl
@@ -39,7 +39,7 @@ println("Started test")
     sysnoise = SVector(1.0, 1.0) * 0.1
     measnoise = SVector(1.0, 1.0) * 0.0
 
-    contsys = ST.NewControlSystemGrowthRK4(
+    contsys = ST.discretize_system_with_growth_bound(
         tstep,
         F_sys,
         L_growthbound,

--- a/test/optim/unit_tests_UniformGridAbstraction/test_fromcontrolsystemlinearized.jl
+++ b/test/optim/unit_tests_UniformGridAbstraction/test_fromcontrolsystemlinearized.jl
@@ -41,7 +41,7 @@ println("Started test")
     bound_DDF(u) = 1.0
     measnoise = SVector(1.0, 1.0) * 0.0
 
-    contsys = ST.NewControlSystemLinearizedRK4(
+    contsys = ST.discretize_system_with_linearization(
         tstep,
         F_sys,
         DF_sys,


### PR DESCRIPTION
We should clean up this `System` module, possibly going closer to MathematicalSystems.jl. Let's start with some renaming to make it look a bit more Julian.
I don't like `NewControlSystemGrowthRK4` because : `New` is not Julian, `ControlSystem` does bring any information that's not already in the signature of the function, `Growth` is nice because in the signature we just have `Function` for the growth bound so we need to specify it, `RK4` not sure if we need it, that's the only option we have anyway.
I'm not saying this is the final naming, we could probably overload methods for this function: https://juliareach.github.io/MathematicalSystems.jl/dev/lib/methods/#MathematicalSystems.discretize by adding new discretization algorithms.