### PR TITLE
Remove Shape

### DIFF
--- a/src/utils/rectangle.jl
+++ b/src/utils/rectangle.jl
@@ -57,13 +57,6 @@ function samples(rect::HyperRectangle, N::Int)
     return [sample(rect) for _ in 1:N]
 end
 
-function rectangle(c, r)
-    return Shape(
-        c[1] .- r[1] .+ [0, 2 * r[1], 2 * r[1], 0],
-        c[2] .- r[2] .+ [0, 0, 2 * r[2], 2 * r[2]],
-    )
-end
-
 @recipe function f(rect::HyperRectangle; dims = [1, 2])
     center = get_center(rect)[dims]
     r = get_h(rect)[dims] ./ 2  # Half-width
@@ -108,7 +101,7 @@ function DeformedRectangleDraw(rect::HyperRectangle, f::Function; N = 10, dims =
     x = [point[1] for point in points]
     y = [point[2] for point in points]
 
-    return DeformedRectangleDraw(rect, f, N, Shape(x, y))
+    return DeformedRectangleDraw(rect, f, N, HyperRectangle(x, y))
 end
 
 @recipe function f(deformed_rect::DeformedRectangleDraw; dims = [1, 2])

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -9,7 +9,7 @@ import LazySets
 import IntervalArithmetic: IntervalBox
 import SpecialFunctions: gamma
 using LinearAlgebra, JuMP
-import Plots: palette, Shape, annotate!
+import Plots: palette, annotate!
 import HiGHS
 
 include("files/files_management.jl")


### PR DESCRIPTION
That's one of the last dependency on Plots
The `rectangle` function seems to be unused now.
For plotting `DeformedRectangleDraw`, maybe we could redirect to `HyperRectangle` somehow ?