### PR TITLE
Fix signature of methods for

### DIFF
--- a/src/domain/grid_domain/grid.jl
+++ b/src/domain/grid_domain/grid.jl
@@ -117,8 +117,8 @@ struct GridFree{N, T} <: Grid{N, T}
     h::SVector{N, T}
 end
 
-get_origin(grid::Grid) = grid.orig
-get_h(grid::Grid) = grid.h
+get_origin(grid::GridFree) = grid.orig
+get_h(grid::GridFree) = grid.h
 
 """
     GridEllipsoidalRectangular{N,T} <: Grid{N,T}


### PR DESCRIPTION
This looks to be a typo, these are method of this specific type, not of the supertype. The method for the supertype is already defined on line 4 anyway
Fixes the warning
```
┌ Dionysos
│  WARNING: Method definition get_origin(Dionysos.Domain.Grid{N, T} where T where N) in module Domain at /home/blegat/.julia/dev/Dionysos/src/domain/grid_domain/grid.jl:14 overwritten at /home/blegat/.julia/dev/Dionysos/src/domain/grid_domain/grid.jl:120.
│  ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
└
```