### PR TITLE
Fix multiple definitions of VectorContinuousSystem

### DIFF
--- a/src/symbolic/timed_hybrid_automaton/vector_continuous_system.jl
+++ b/src/symbolic/timed_hybrid_automaton/vector_continuous_system.jl
@@ -5,9 +5,6 @@ struct VectorContinuousSystem{T <: AbstractContinuousSystem} <: AbstractContinuo
     systems::Vector{T}
 end
 
-VectorContinuousSystem(systems::Vector{<:AbstractContinuousSystem}) =
-    VectorContinuousSystem{AbstractContinuousSystem}(systems)
-
 MathematicalSystems.stateset(sys::VectorContinuousSystem) =
     Tuple(MathematicalSystems.stateset(s) for s in sys.systems)
 


### PR DESCRIPTION
Fixes the warning
```
WARNING: Method definition (::Type{Dionysos.Symbolic.VectorContinuousSystem{T} where T<:MathematicalSystems.AbstractContinuousSystem})(Array{var"#s892", 1} where var"#s892"<:MathematicalSystems.AbstractContinuousSystem) in module Symbolic at /home/runner/.julia/packages/Dionysos/AQtid/src/symbolic/timed_hybrid_automaton/vector_continuous_system.jl:5 overwritten at /home/runner/.julia/packages/Dionysos/AQtid/src/symbolic/timed_hybrid_automaton/vector_continuous_system.jl:8.
```